### PR TITLE
Add configurable per-project pattern generation string

### DIFF
--- a/lib/project-colorize.coffee
+++ b/lib/project-colorize.coffee
@@ -1,12 +1,51 @@
 GeoPattern = require 'geopattern'
 
 module.exports =
-  activate: (state) ->
-    pattern = GeoPattern.generate atom.project.getPaths().sort().join(':')
+  config:
+    defaultPatternString:
+      type: 'string'
+      default: ''
+      description: 'Used to generate the pattern when no project folder is open'
+      order: 1
+    noPatternOnEmptyString:
+      type: 'boolean'
+      default: true
+      order: 2
 
+  configPath: 'project-colorize.defaultPatternString'
+
+  activate: (state) ->
+    # Default to using the project path(s) to generate the pattern
+    projectPaths = atom.project.getPaths().sort().join(':')
+
+    # Get config path for this set of project paths
+    @configPath = 'project-colorize.' + projectPaths if projectPaths
+
+    # Get custom pattern string
+    patternString = atom.config.get @configPath
+
+    if not patternString?
+      # No custom pattern string was found, save project paths as pattern string
+      atom.config.set @configPath, projectPaths
+
+    # Observe config changes
+    atom.config.observe @configPath, => @setPattern()
+    atom.config.observe 'project-colorize.noPatternOnEmptyString', => @setPattern()
+
+  setPattern: () ->
+    # Generate the pattern
+    patternString = atom.config.get @configPath
+    pattern = GeoPattern.generate patternString
+
+    # TODO: Remove any earlier <style> element created by this package?
     style = document.createElement 'style'
     style.type = 'text/css'
-    style.innerText =  '.tab-bar { background-image: ' + pattern.toDataUrl() + ';}'
+
+    if not patternString and atom.config.get 'project-colorize.noPatternOnEmptyString'
+      style.innerText = '.tab-bar { background-image: none;}'
+    else
+      style.innerText = '.tab-bar { background-image: ' + pattern.toDataUrl() + ';}'
 
     workspaceElement = atom.views.getView atom.workspace
     workspaceElement.appendChild style
+


### PR DESCRIPTION
Fixes https://github.com/jasonporritt/project-colorize/issues/5.

This branch creates a config option for every new project, which allows the pattern for a project to be customized. If the pattern generation string is not customized, it should behave exactly like it does now.

I also added config options to remove the pattern if the generation string is empty. This is the case if no project directory is open (i.e. if you only open a single file in Atom), or if the custom string is empty.

I've been using this for a couple of weeks and it seems to be working well. The config options are observed, so you should be able to see the pattern change immediately. It even works for multiple windows, which surprised me a bit (Atom seems to handle this automatically).
